### PR TITLE
info.plist: Remove extra line from workflow description

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -291,8 +291,7 @@
 	<key>createdby</key>
 	<string>Chris Grieser</string>
 	<key>description</key>
-	<string>Search neovim plugins and online :help via Alfred
-Search neovim plugins and online :help via Alfred</string>
+	<string>Search neovim plugins and online :help via Alfred</string>
 	<key>disabled</key>
 	<false/>
 	<key>name</key>


### PR DESCRIPTION
Just noted there’s an extraneous repeated line in the workflow’s description.

By the way, in all these PRs it’s fine to close and do it yourself if that’s easier.